### PR TITLE
Fix README.md path in application

### DIFF
--- a/bin/eflex
+++ b/bin/eflex
@@ -26,7 +26,7 @@ main([]) ->
 main(["--help" = Opt]) ->
     AppDir = ensure_app_dir(true),
     require_app(eflex, Opt),
-    File = filename:join([AppDir, "README"]),
+    File = filename:join([AppDir, "README.md"]),
     case file:read_file(File) of
 	{ok, Bin} ->
 	    io:format("~s\n", [binary_to_list(Bin)]);

--- a/src/eflex_wx.erl
+++ b/src/eflex_wx.erl
@@ -527,7 +527,7 @@ handle_other(#state{main_frame = Mframe,
 			    {file, BeamFile} = code:is_loaded(?MODULE),
 			    EbinDir = filename:dirname(BeamFile),
 			    AppDir = filename:dirname(EbinDir),
-			    HelpFile = filename:join([AppDir, "README"]),
+			    HelpFile = filename:join([AppDir, "README.md"]),
 			    Url = "file://" ++ filename:absname(HelpFile),
 			    wx_misc:launchDefaultBrowser(Url),
 			    S;


### PR DESCRIPTION
Previous change messed up the User Guide path to the README.md from the application. This should fix it. Sorry. =/
