### PR TITLE
Erlang/OTP 24, new wx 3 API and macOS

### DIFF
--- a/src/eflex_wx.erl
+++ b/src/eflex_wx.erl
@@ -388,14 +388,14 @@ handle_other(#state{main_frame = Mframe,
     case Event of
 	{select_activity, Row, _Col} ->
 	    wx:batch(fun() -> activity_popup(S, Row) end);
-	{copy_cell, Row, Col, _X, _Y} ->
+	{copy_cell, Row, Col} ->
 	    case wxGrid:getCellValue(MainGrid, Row, Col) of
 		[$- | Time] -> ok; % Use abs val
 		Time -> ok
 	    end,
 	    clipboard_copy(Time),
 	    S#state{selected_time = Time};
-	{paste_cell, Row, Col, _X, _Y} ->
+	{paste_cell, Row, Col} ->
 	    S2 = 
 		case clipboard_paste() of
 		    {ok, T} ->
@@ -1938,9 +1938,7 @@ grid_cell_left_click(WinPid,
 		     UnspecRow,
 		     #wx{event = #wxGrid{type = _Type,
 					 row = Row,
-					 col = Col,
-					 x = X,
-					 y = Y}},
+					 col = Col}},
 		     EventRef) ->
     if
 	Col =:= ?ACTIVITY_COL ->
@@ -1952,15 +1950,15 @@ grid_cell_left_click(WinPid,
 	Row =:= ?DATE_ROW ->
 	    WinPid ! {toggle_holiday, Row, Col};
 	Row =:= ?BREAK_ROW ->
-	    WinPid ! {copy_cell, Row, Col, X, Y};
+	    WinPid ! {copy_cell, Row, Col};
 	Row =:= ?WORK_ROW ->
-	    WinPid ! {copy_cell, Row, Col, X, Y};
+	    WinPid ! {copy_cell, Row, Col};
 	Row =:= ?FLEX_ROW ->
-	    WinPid ! {copy_cell, Row, Col, X, Y};
+	    WinPid ! {copy_cell, Row, Col};
 	Row =:= UnspecRow ->
-	    WinPid ! {copy_cell, Row, Col, X, Y};
+	    WinPid ! {copy_cell, Row, Col};
 	true ->
-	    WinPid ! {copy_cell, Row, Col, X, Y},
+	    WinPid ! {copy_cell, Row, Col},
 	    wxEvent:skip(EventRef)
     end.
 
@@ -1975,9 +1973,7 @@ grid_cell_middle_click(WinPid,
     Row = wxGrid:yToRow(Grid, Y),
     Fake = #wxGrid{type = grid_cell_right_click,
 		   row = Row,
-		   col = Col,
-		   x = X,
-		   y = Y},
+		   col = Col},
     grid_cell_right_click(WinPid,
 			  UnspecRow,
 			  Wx#wx{event = Fake},
@@ -1987,9 +1983,7 @@ grid_cell_right_click(WinPid,
 		      UnspecRow,
 		      #wx{event = #wxGrid{type = _Type,
 					  row = Row,
-					  col = Col,
-					  x = X,
-					  y = Y}} = Wx,
+					  col = Col}} = Wx,
 		      EventRef) ->
     if
         Row =/= ?DATE_ROW,
@@ -2000,7 +1994,7 @@ grid_cell_right_click(WinPid,
         Col =/= ?ACTIVITY_COL,
         Col =/= ?YEAR_SUM_COL,
         Col =/= ?WEEK_SUM_COL ->
-	    WinPid ! {paste_cell, Row, Col, X, Y};
+	    WinPid ! {paste_cell, Row, Col};
 	true ->
 	    grid_cell_left_click(WinPid,
 				 UnspecRow,

--- a/src/eflex_wx.erl
+++ b/src/eflex_wx.erl
@@ -2821,7 +2821,7 @@ update_week(#state{options = #options{date = Date, n_rows = Nrows},
 				    Color =
 					case IsHoliday of
 					    true  -> ?wxRED;
-					    false -> ?wxBLACK
+					    false -> wxGrid:getDefaultCellTextColour(MainGrid)
 					end,
 				    wxGrid:setCellTextColour(MainGrid,
 							     Row,
@@ -2855,7 +2855,7 @@ update_week(#state{options = #options{date = Date, n_rows = Nrows},
                                             wxGrid:setCellTextColour(MainGrid,
 								     Row,
 								     Col,
-								     ?wxBLACK);
+								     wxGrid:getDefaultCellTextColour(MainGrid));
                                         Name =:= ?FLEX_ACT,
 					Col =/= ?YEAR_SUM_COL,
 					Col =/= ?WEEK_SUM_COL ->
@@ -2875,7 +2875,8 @@ update_week(#state{options = #options{date = Date, n_rows = Nrows},
 						    wxGrid:setCellTextColour(MainGrid,
 									     Row,
 									     Col,
-									     ?wxBLACK)
+									     wxGrid:getDefaultCellTextColour(
+											 MainGrid))
 					    end;
 					Col =/= ?YEAR_SUM_COL,
 					Col =/= ?WEEK_SUM_COL ->

--- a/src/eflex_wx.erl
+++ b/src/eflex_wx.erl
@@ -1217,7 +1217,15 @@ cell_set_read_only(Grid, Row, Col) ->
 
 cell_set_read_write(Grid, Row, Col) ->
     wxGrid:setReadOnly(Grid, Row, Col, [{isReadOnly, false}]),
-    wxGrid:setCellBackgroundColour(Grid, Row, Col, ?wxWHITE).
+    BG = case is_dark_mode(wxGrid:getLabelBackgroundColour(Grid)) of
+             true -> wxSystemSettings:getColour(?wxSYS_COLOUR_BTNSHADOW);
+             false -> ?wxWHITE
+         end,
+    wxGrid:setCellBackgroundColour(Grid, Row, Col, BG).
+
+is_dark_mode({R,G,B,_}) ->
+    ((R+G+B) div 3) < 100.
+
 
 recreate_activity_type_window(#state{activity_frame = undefined} = S) ->
     S;


### PR DESCRIPTION
Hi,

From having run eflex on a linux laptop and using an older version of Erlang/OTP and wx, I recently switched to macOS and Erlang/OTP 24 and the new wx 3 API and things failed. The goal with this PR is to mitigate those issues and allow eflex to run on newer configurations.

Versions used:

- macOS Monterey, 12.1
- Erlang/OTP 24.1.7 with erts-12.1.5 and wx-2.1
- wxwidgets: stable 3.1.5

In its current form it is not yet quite ready, the fixes seem to work but require a more testing on a linux machine yet (I'll have to set up a VM to do that), but raising this PR to get some feedback and as a heads up. The biggest change that I'm confused about is the "Fix automatic fitting", where I could not seem to find something that worked (automatic layout and fitting) with the panel-level so I made a version without it.

Comments are welcome.

Here's what I have in mind for things to do:

- Checking that the changes overall seem to work on linux, including checking that the clipboard changes still work on linux (middle mouse click).
- There seems to be an issue with changes not being always saved. I don't know if this is related to macOS, new wxwidgets or something else. What I have observed is: The saves won't happen if I close the window using the "cross" on the window itself. This applies to both the "Edit..." dialogs and the main window. If I use the menus to close they seem to be saved. I saw this morning that just editing a cell and then pressing enter doesn't save the values, but clicking on another cell using the mouse saves. Will need more looking into.

Cheers,
Klas